### PR TITLE
Remove focus from element of newly-rendered synonym list with same in…

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -8,6 +8,7 @@
         :mainWord='this.mainWord'
         @find-synonyms='findSynonyms'
         :error='this.error'
+        ref='search'
         />
       <ListOutput 
         :synonyms='this.synonyms'
@@ -47,9 +48,13 @@ export default {
         const partOfSpeech = rawResponse.fl;
         const synonyms = rawResponse.meta.syns[0];
         this.handleResponse(mainWord, definition, partOfSpeech, synonyms);
+        console.log(this.$refs)
+        this.$refs.search.$el[0].focus();
       } catch ({ message }) {
         if (message === 'Sorry, we couldn\'t find the word you were looking for! Please enter a new word.') {
         this.handleError(message);
+        console.log(this.$refs)
+        this.$refs.search.$el[0].focus();
         }
       } 
     },

--- a/src/components/ListOutput/ListOutput.vue
+++ b/src/components/ListOutput/ListOutput.vue
@@ -6,8 +6,8 @@
       <li 
       v-for='(synonym, index) in this.synonyms' 
       v-bind:key='index'
-      @click.prevent="findWord(synonym)"
-      @keyup.enter.prevent="findWord(synonym)"
+      @click.prevent="findWord($event, synonym)"
+      @keyup.enter.prevent="findWord($event, synonym)"
       tabindex='0'
       >{{synonym}}
       </li>
@@ -20,9 +20,10 @@ export default {
   name: 'listoutput',
   props: ['synonyms'],
   methods: {
-    findWord(word) {
+    findWord(event, word) {
       this.$emit('find-synonyms', word);
       this.word = ''
+      event.target.blur();
     }
   }
 }


### PR DESCRIPTION
…dex as previous element clicked, put focus on input element of form with refs

#### What’s this PR do?

Removes focus from a word clicked/entered on in the synonyms list after new definition and synonyms are displayed, and returns focus to the input field of the form  by passing ref to Form component.

#### Where should the reviewer start?

Changes have been made in App and ListOutput. 

#### How should this be manually tested?

A word should not remain focused after clicking it in the synonyms list, and focus should return to the form input after searching. 

#### Any background context you want to provide?
#### What are the relevant tickets?

See below.

#### Screenshots (if appropriate)
#### Questions:
# Implements/Fixes:
* What issue does this close?

#19 
